### PR TITLE
Use .env for secrets in infrastructure repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Environment variables for docker-compose services
+# Copy to .env and set actual values.
+GENERIC_TIMEZONE=Europe/Moscow
+DISCOURSE_API_KEY=
+DISCOURSE_API_USER=
+TELEGRAM_BOT_TOKEN=
+INFLUXDB_URL=
+INFLUXDB_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ vaultwarden/*
 
 # Logs
 *.log
+
+# Local environment files
+.env

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **n8n** – агрегация данных, проверка SLA, уведомления.
 - **InfluxDB** – хранение SLA‑логов.
 - **Grafana** – визуализация статистики и отчётов.
-- Секреты (Discourse API, Telegram Bot, InfluxDB) хранятся в n8n Credentials, в Git попадает только логика workflow.
+- Секреты (Discourse API, Telegram Bot, InfluxDB) хранятся в файле `.env` и в n8n Credentials; `.env` не коммитится, в Git попадает только логика workflow.
 
 ## SLA‑правила
 - Первый ответ и время реакции – не более 2 часов в рабочее время (пн–пт, 9:00–18:00 МСК).
@@ -65,6 +65,7 @@ Data Explorer / Discourse API. SQL‑запрос возвращает:
 В Git хранятся:
 - `docker-compose.yml`;
 - конфиги Grafana, InfluxDB, n8n workflows (без секретов).
+- файл `.env.example` (образец). Настоящий `.env` с секретами хранится локально и не коммитится.
 
 Все изменения проходят через коммиты и redeploy. Развёртывание контейнеров из Git на сервере.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@ services:
   n8n:
     image: n8nio/n8n:latest
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
-      - GENERIC_TIMEZONE=Europe/Moscow
+      - GENERIC_TIMEZONE=${GENERIC_TIMEZONE}
     ports:
       - "5678:5678"
     volumes:
@@ -14,6 +16,8 @@ services:
   influxdb:
     image: influxdb:2.7
     restart: unless-stopped
+    env_file:
+      - .env
     ports:
       - "8086:8086"
     volumes:
@@ -22,6 +26,8 @@ services:
   grafana:
     image: grafana/grafana:latest
     restart: unless-stopped
+    env_file:
+      - .env
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
## Summary
- Load environment variables from `.env` in docker-compose
- Ignore real `.env` files and add `.env.example`
- Document `.env` usage for secrets

## Testing
- `docker-compose config >/tmp/dc-config.log && tail -n 20 /tmp/dc-config.log`


------
https://chatgpt.com/codex/tasks/task_e_68a5bc336f08832788f46be269f12274