### PR TITLE
Add initial monitoring configs for SLA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,13 @@ n8n/*
 grafana/*
 influxdb/*
 vaultwarden/*
+!n8n/*.json
+!grafana/*.json
+!influxdb/*.json
+!vaultwarden/.gitkeep
 !n8n/.gitkeep
 !grafana/.gitkeep
 !influxdb/.gitkeep
-!vaultwarden/.gitkeep
 
 # Logs
 *.log

--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ python3 -m pytest -q
 Тесты проверяют сценарии предупреждений и нарушения SLA, включая учёт
 выходных и времени вне рабочего дня.
 
+
+## Файлы конфигурации
+
+- `grafana/datasource-influxdb.json` – настройка источника данных InfluxDB для Grafana.
+- `grafana/dashboard-sla.json` – дашборд с визуализацией нарушений SLA.
+- `influxdb/buckets.json` – bucket `sla` и политика хранения на 30 дней.
+- `influxdb/retention-policies.json` – параметры политики retention для `sla`.
+- `influxdb/users.json` – пользователь `sla_writer` и его токен.
+- `n8n/sla-check.json` – workflow проверки SLA и отправки уведомлений.
+- `n8n/daily-report.json` – workflow ежедневного отчёта по нарушениям.

--- a/grafana/dashboard-sla.json
+++ b/grafana/dashboard-sla.json
@@ -1,0 +1,14 @@
+{
+  "title": "SLA Overview",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "SLA Violations",
+      "targets": [
+        {
+          "query": "from(bucket: \"sla\") |> range(start: -30d) |> filter(fn: (r) => r[\"event_type\"] == \"violation\")"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/datasource-influxdb.json
+++ b/grafana/datasource-influxdb.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": 1,
+  "datasources": [
+    {
+      "name": "InfluxDB",
+      "type": "influxdb",
+      "access": "proxy",
+      "url": "http://influxdb:8086",
+      "isDefault": true,
+      "jsonData": {
+        "version": "Flux",
+        "organization": "wb",
+        "defaultBucket": "sla"
+      }
+    }
+  ]
+}

--- a/influxdb/buckets.json
+++ b/influxdb/buckets.json
@@ -1,0 +1,13 @@
+{
+  "buckets": [
+    {
+      "name": "sla",
+      "retentionRules": [
+        {
+          "type": "expire",
+          "everySeconds": 2592000
+        }
+      ]
+    }
+  ]
+}

--- a/influxdb/retention-policies.json
+++ b/influxdb/retention-policies.json
@@ -1,0 +1,11 @@
+{
+  "retentionPolicies": [
+    {
+      "name": "30d",
+      "duration": "720h",
+      "replication": 1,
+      "default": true,
+      "bucket": "sla"
+    }
+  ]
+}

--- a/influxdb/users.json
+++ b/influxdb/users.json
@@ -1,0 +1,13 @@
+{
+  "users": [
+    {
+      "name": "sla_writer",
+      "password": "CHANGE_ME",
+      "token": "sla-writer-token",
+      "permissions": {
+        "read": [],
+        "write": ["sla"]
+      }
+    }
+  ]
+}

--- a/n8n/daily-report.json
+++ b/n8n/daily-report.json
@@ -1,0 +1,65 @@
+{
+  "name": "Daily SLA Report",
+  "nodes": [
+    {
+      "parameters": {
+        "triggerTimes": {
+          "item": [
+            {
+              "hour": 8,
+              "minute": 0
+            }
+          ]
+        }
+      },
+      "name": "Cron",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [250, 300]
+    },
+    {
+      "parameters": {
+        "functionCode": "// compile report\nreturn items;"
+      },
+      "name": "Function",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [450, 300]
+    },
+    {
+      "parameters": {
+        "text": "Daily SLA report"
+      },
+      "name": "Telegram",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [650, 300]
+    }
+  ],
+  "connections": {
+    "Cron": {
+      "main": [
+        [
+          {
+            "node": "Function",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function": {
+      "main": [
+        [
+          {
+            "node": "Telegram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "id": "2"
+}

--- a/n8n/sla-check.json
+++ b/n8n/sla-check.json
@@ -1,0 +1,129 @@
+{
+  "name": "SLA Check",
+  "nodes": [
+    {
+      "parameters": {
+        "triggerTimes": {
+          "item": [
+            {
+              "hour": "*",
+              "minute": "*/30"
+            }
+          ]
+        }
+      },
+      "name": "Cron",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [250, 300]
+    },
+    {
+      "parameters": {
+        "url": "https://discourse.example/api",
+        "responseFormat": "json"
+      },
+      "name": "HTTP Request",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [450, 300]
+    },
+    {
+      "parameters": {
+        "functionCode": "// calculate SLA\nreturn items;"
+      },
+      "name": "Function",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [650, 300]
+    },
+    {
+      "parameters": {
+        "rules": [
+          {
+            "type": "expression",
+            "value1": "{{$json.event}}",
+            "operation": "equal",
+            "value2": "violation"
+          }
+        ]
+      },
+      "name": "Switch",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 1,
+      "position": [850, 300]
+    },
+    {
+      "parameters": {
+        "text": "SLA warning"
+      },
+      "name": "Telegram",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [1050, 260]
+    },
+    {
+      "parameters": {
+        "bucket": "sla"
+      },
+      "name": "InfluxDB",
+      "type": "n8n-nodes-base.influxdb",
+      "typeVersion": 1,
+      "position": [1050, 340]
+    }
+  ],
+  "connections": {
+    "Cron": {
+      "main": [
+        [
+          {
+            "node": "HTTP Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "HTTP Request": {
+      "main": [
+        [
+          {
+            "node": "Function",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function": {
+      "main": [
+        [
+          {
+            "node": "Switch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch": {
+      "main": [
+        [
+          {
+            "node": "Telegram",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "InfluxDB",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "id": "1"
+}


### PR DESCRIPTION
## Summary
- add sample Grafana datasource and dashboard for SLA metrics
- include InfluxDB bucket, retention and user setup files
- export n8n workflows for SLA checks and daily reports

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c35b169c8327a89524496ba25cdd