### PR TITLE
Fix n8n start command in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   n8n:
     image: n8nio/n8n:latest
     restart: unless-stopped
-    command: "n8n start"
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Summary
- remove explicit `n8n start` command to rely on image defaults

## Testing
- ⚠️ `docker compose config` *(missing: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f1938c048327b200928e9ca781d8