### PR TITLE
Support local infrastructure without Traefik

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Environment variables for docker-compose services
 # Copy to .env and set actual values.
+# DOMAIN_NAME, SUBDOMAIN and SSL_EMAIL are required only when running behind Traefik.
 DOMAIN_NAME=example.com
 SUBDOMAIN=n8n
 SSL_EMAIL=user@example.com

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ Data Explorer / Discourse API. SQL‑запрос возвращает:
    - Grafana – `curl -I http://localhost:3000/login`
    - n8n – `curl -I https://$SUBDOMAIN.$DOMAIN_NAME`
 
+### Локальный запуск без Traefik
+
+Для разработки или тестирования сервисы можно поднять без Traefik, используя
+отдельный compose-файл:
+
+1. Скопируйте `.env.example` в `.env` и заполните переменные для InfluxDB.
+   Параметры `DOMAIN_NAME`, `SUBDOMAIN` и `SSL_EMAIL` в локальном режиме не используются.
+2. Запустите контейнеры:
+   ```bash
+   docker compose -f docker-compose.local.yml up -d
+   ```
+3. Проверка сервисов:
+   - InfluxDB – `curl -I http://localhost:8086/health`
+   - Grafana – `curl -I http://localhost:3000/login`
+   - n8n – `curl -I http://localhost:5678`
+
 ## Локальная проверка SLA
 Для тестирования логики SLA в репозитории есть простой Python‑модуль `sla`,
 который рассчитывает статус тикета с учётом рабочих часов. Запустить проверки

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,51 @@
+services:
+  n8n:
+    image: docker.n8n.io/n8nio/n8n
+    restart: always
+    env_file:
+      - .env
+    ports:
+      - "5678:5678"
+    environment:
+      - N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true
+      - N8N_HOST=localhost
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=http
+      - N8N_RUNNERS_ENABLED=true
+      - NODE_ENV=production
+      - WEBHOOK_URL=http://localhost:5678/
+      - GENERIC_TIMEZONE=${GENERIC_TIMEZONE}
+      - TZ=${GENERIC_TIMEZONE}
+    volumes:
+      - n8n_data:/home/node/.n8n
+      - ./local-files:/files
+
+  influxdb:
+    image: influxdb:2.7
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=${INFLUXDB_USERNAME}
+      - DOCKER_INFLUXDB_INIT_PASSWORD=${INFLUXDB_PASSWORD}
+      - DOCKER_INFLUXDB_INIT_ORG=${INFLUXDB_ORG}
+      - DOCKER_INFLUXDB_INIT_BUCKET=${INFLUXDB_BUCKET}
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUXDB_ADMIN_TOKEN}
+    ports:
+      - "8086:8086"
+    volumes:
+      - ./influxdb:/var/lib/influxdb2
+
+  grafana:
+    image: grafana/grafana:latest
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana:/var/lib/grafana
+
+volumes:
+  n8n_data:


### PR DESCRIPTION
## Summary
- clarify Traefik variables in `.env.example`
- document how to run services locally without Traefik
- add `docker-compose.local.yml` with direct port mappings for n8n, InfluxDB and Grafana

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f7c785408327895eea43794bf87c