### PR TITLE
fix: run grafana as root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ curl -I http://localhost:3000/login
 ```
 Default login: `admin` / `admin`.
 
+The Grafana container runs as the root user so it can write to the local
+`grafana/` directory used for data persistence.
+
 ### Step 3 – n8n
 ```bash
 docker compose up -d n8n

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
   grafana:
     image: grafana/grafana:10.4.0
     restart: unless-stopped
+    user: "0"
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
## Summary
- run grafana container as root to avoid restart due to permissions
- mention grafana runs as root for writing to data directory

## Testing
- `python - <<'PY'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a72012da788327b52c4abde474fed9