### PR TITLE
Disable secure cookie for n8n local use

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,7 @@ curl -I http://localhost:5678
 ```
 Open http://localhost:5678 in a browser to access the editor.
 
+n8n is configured for local use without HTTPS; the `N8N_SECURE_COOKIE` option
+is set to `false` so the editor works over plain HTTP.
+
 Data is stored in `influxdb/`, `grafana/`, `n8n/` and `local-files/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       WEBHOOK_URL: http://localhost:5678/
       N8N_USER_FOLDER: /home/node/.n8n
       HOME: /home/node
+      N8N_SECURE_COOKIE: "false"
     ports:
       - "5678:5678"
     volumes:


### PR DESCRIPTION
## Summary
- disable n8n secure cookie in docker-compose for local HTTP access
- note in README that N8N_SECURE_COOKIE=false allows plain HTTP

## Testing
- `docker compose config` (command not found: docker)


------
https://chatgpt.com/codex/tasks/task_e_68a7365f5ed0832781991064c802c32d