### PR TITLE
docs: warn about default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Infrastructure for monitoring SLA violations with InfluxDB, Grafana and n8n.
 
+> ⚠️ Default credentials for InfluxDB and Grafana are hardcoded in
+> `docker-compose.yml` for quick local setup. **Change them before using this
+> stack in any shared or production environment.**
+
 ## Quick start
 
 Run services step by step.
@@ -11,14 +15,16 @@ Run services step by step.
 docker compose up -d influxdb
 curl -I http://localhost:8086/health
 ```
-Default login: `admin` / `adminpassword`, token `admintoken`.
+Default login: `admin` / `adminpassword`, token `admintoken`. Update these
+values in `docker-compose.yml` to secure your deployment.
 
 ### Step 2 – Grafana
 ```bash
 docker compose up -d grafana
 curl -I http://localhost:3000/login
 ```
-Default login: `admin` / `admin`.
+Default login: `admin` / `admin`. Update these values in `docker-compose.yml`
+to secure your deployment.
 
 The Grafana container runs as the root user so it can write to the local
 `grafana/` directory used for data persistence.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     ports:
       - "8086:8086"
     environment:
+      # Default credentials for local development.
+      # Change these values before deploying anywhere serious.
       DOCKER_INFLUXDB_INIT_USERNAME: admin
       DOCKER_INFLUXDB_INIT_PASSWORD: adminpassword
       DOCKER_INFLUXDB_INIT_ORG: default
@@ -20,6 +22,8 @@ services:
     ports:
       - "3000:3000"
     environment:
+      # Default Grafana admin credentials for local use.
+      # Change these values before deploying anywhere serious.
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
     volumes:


### PR DESCRIPTION
## Summary
- remind to change hardcoded default credentials for InfluxDB and Grafana
- annotate docker-compose with warnings about credentials

## Testing
- `docker-compose config >/tmp/compose_config.out && tail -n 20 /tmp/compose_config.out`


------
https://chatgpt.com/codex/tasks/task_e_68a741cacc988327a6beacd83a670ff6